### PR TITLE
Upgrade docker-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-client</artifactId>
-            <version>8.8.3</version>
-        </dependency>
-        <dependency>
             <groupId>org.hobbit</groupId>
             <artifactId>core</artifactId>
             <version>0.0.1-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.hobbit.sdk</groupId>
     <artifactId>sdk-example-benchmark</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.3.1</version>
+            <version>8.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.hobbit</groupId>


### PR DESCRIPTION
Previous versions fail to handle response returned by `/networks` endpoint.